### PR TITLE
fix(feed): use content-search API for Unity webview feed

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/setup-node@v2
 
       - name: cache deps
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         id: cache-deps
         with:
           path: |

--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/setup-node@v2
 
       - name: cache deps
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         id: cache-deps
         with:
           path: |

--- a/.github/workflows/staging.yaml
+++ b/.github/workflows/staging.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/setup-node@v2
 
       - name: cache deps
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         id: cache-deps
         with:
           path: |

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/setup-node@v2
 
       - name: cache deps
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         id: cache-deps
         with:
           path: |

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,3 +1,8 @@
+export const AMITY_API_KEY = 'b0e8b9593bdca3634565db15030942de8301ddb3e9373c2c';
+export const AMITY_GLOBAL_CATEGORY_ID = '71652faa3729304f3bbc369849f6708e';
+export const BBVR_GLOBAL_COMMUNITY_ID = '64af01593714fddb10e0c7d2';
+export const CONTENT_SEARCH_API_URL = 'https://beta.amity.services/search/v2/posts';
+
 export const LIKE_REACTION_KEY = 'like';
 export const BANNER_SPRITES_URL = 'https://bbvr-banner-sprites.s3-us-west-2.amazonaws.com';
 export const WEB_COMMUNITY_URL = 'https://community.blackbox-vr.com';

--- a/src/social/components/Feed/index.js
+++ b/src/social/components/Feed/index.js
@@ -26,13 +26,11 @@ const queryParams = { filter: CommunityFilter.Member };
 const renderLoadingSkeleton = () =>
   new Array(3).fill(3).map((x, index) => <DefaultPostRenderer key={index} loading />);
 
-const Feed = ({
+const FeedBody = ({
   className = null,
   feedType,
   targetType = PostTargetType.MyFeed,
   targetId = '',
-  searchType,
-  showTargetId,
   useContentSearch = false,
   showPostCreator = false,
   onPostCreated,
@@ -41,39 +39,16 @@ const Feed = ({
   isHiddenProfile = false,
   showOptionMenu,
   isHideWhenEmpty = false,
+  posts,
+  hasMore,
+  loadMore,
+  loading,
+  loadingMore,
+  error = null,
+  retry = () => {},
+  prependPost = () => {},
 }) => {
-  const { currentUserId } = useSDK();
   const enablePostTargetPicker = false;
-
-  const sdkFeed = useFeed({
-    targetType,
-    targetId,
-    feedType,
-  });
-  const contentSearchFeed = useSearchFeed({
-    targetType,
-    targetId,
-    loginUserId: currentUserId,
-    searchType,
-    showTargetId,
-    defaultNumber,
-    queryLimit: perPageNumber,
-    enabled: useContentSearch,
-  });
-
-  const [posts, hasMore, loadMore, loading, loadingMore] = useContentSearch
-    ? [
-        contentSearchFeed.posts,
-        contentSearchFeed.hasMore,
-        contentSearchFeed.loadMore,
-        contentSearchFeed.loading,
-        contentSearchFeed.loadingMore,
-      ]
-    : sdkFeed;
-
-  const { error, prependPost, retry } = useContentSearch
-    ? contentSearchFeed
-    : { error: null, prependPost: () => {}, retry: () => {} };
 
   const [communities, hasMoreCommunities, loadMoreCommunities] = useCommunitiesList(
     queryParams,
@@ -181,6 +156,65 @@ const Feed = ({
   );
 };
 
+const SdkFeed = (props) => {
+  const { feedType, targetType, targetId } = props;
+  const [posts, hasMore, loadMore, loading, loadingMore] = useFeed({
+    targetType,
+    targetId,
+    feedType,
+  });
+
+  return (
+    <FeedBody
+      {...props}
+      posts={posts}
+      hasMore={hasMore}
+      loadMore={loadMore}
+      loading={loading}
+      loadingMore={loadingMore}
+      useContentSearch={false}
+    />
+  );
+};
+
+const ContentSearchFeed = (props) => {
+  const { currentUserId } = useSDK();
+  const { targetType, targetId, searchType, showTargetId } = props;
+  const { posts, hasMore, loadMore, loading, loadingMore, error, prependPost, retry } =
+    useSearchFeed({
+      targetType,
+      targetId,
+      loginUserId: currentUserId,
+      searchType,
+      showTargetId,
+      defaultNumber,
+      queryLimit: perPageNumber,
+    });
+
+  return (
+    <FeedBody
+      {...props}
+      posts={posts}
+      hasMore={hasMore}
+      loadMore={loadMore}
+      loading={loading}
+      loadingMore={loadingMore}
+      error={error}
+      retry={retry}
+      prependPost={prependPost}
+      useContentSearch
+    />
+  );
+};
+
+const Feed = ({ useContentSearch = false, ...props }) => {
+  if (useContentSearch) {
+    return <ContentSearchFeed {...props} useContentSearch />;
+  }
+
+  return <SdkFeed {...props} />;
+};
+
 Feed.propTypes = {
   className: PropTypes.string,
   feedType: PropTypes.oneOf(Object.values(FeedType)),
@@ -190,11 +224,11 @@ Feed.propTypes = {
   showTargetId: PropTypes.string,
   useContentSearch: PropTypes.bool,
   showPostCreator: PropTypes.bool,
-  goToExplore: PropTypes.func,
   readonly: PropTypes.bool,
   isHiddenProfile: PropTypes.bool,
   showOptionMenu: PropTypes.bool,
   isHideWhenEmpty: PropTypes.bool,
+  goToExplore: PropTypes.func,
   onPostCreated: PropTypes.func,
 };
 

--- a/src/social/components/Feed/index.js
+++ b/src/social/components/Feed/index.js
@@ -1,9 +1,10 @@
-import React, { memo, useState } from 'react';
+import React, { memo } from 'react';
 import PropTypes from 'prop-types';
 import { PostTargetType, FeedType, CommunityFilter } from '@amityco/js-sdk';
 
 import { useSDK } from '~/core/hooks/useSDK';
 import useCommunitiesList from '~/social/hooks/useCommunitiesList';
+import useFeed from '~/social/hooks/useFeed';
 import useSearchFeed from '~/social/hooks/useSearchFeed';
 
 import customizableComponent from '~/core/hocs/customization';
@@ -12,14 +13,18 @@ import DefaultPostRenderer from '~/social/components/post/Post/DefaultPostRender
 import PostCreator from '~/social/components/post/Creator';
 import Post from '~/social/components/post/Post';
 import ConditionalRender from '~/core/components/ConditionalRender';
+import EmptyFeed from '~/social/components/EmptyFeed';
 import LoadMore from '~/social/components/LoadMore';
 import PrivateFeed from '~/social/components/PrivateFeed';
 
-import { FeedScrollContainer } from './styles';
+import { FeedScrollContainer, FeedError } from './styles';
 
 const defaultNumber = 10;
 const perPageNumber = 10;
 const queryParams = { filter: CommunityFilter.Member };
+
+const renderLoadingSkeleton = () =>
+  new Array(3).fill(3).map((x, index) => <DefaultPostRenderer key={index} loading />);
 
 const Feed = ({
   className = null,
@@ -28,19 +33,24 @@ const Feed = ({
   targetId = '',
   searchType,
   showTargetId,
+  useContentSearch = false,
   showPostCreator = false,
   onPostCreated,
   goToExplore,
   readonly = false,
   isHiddenProfile = false,
   showOptionMenu,
+  isHideWhenEmpty = false,
 }) => {
   const { currentUserId } = useSDK();
-
   const enablePostTargetPicker = false;
-  const [page, setPage] = useState(1);
 
-  const [posts, hasMore, loadMore, loading, loadingMore] = useSearchFeed({
+  const sdkFeed = useFeed({
+    targetType,
+    targetId,
+    feedType,
+  });
+  const contentSearchFeed = useSearchFeed({
     targetType,
     targetId,
     loginUserId: currentUserId,
@@ -48,67 +58,123 @@ const Feed = ({
     showTargetId,
     defaultNumber,
     queryLimit: perPageNumber,
+    enabled: useContentSearch,
   });
+
+  const [posts, hasMore, loadMore, loading, loadingMore] = useContentSearch
+    ? [
+        contentSearchFeed.posts,
+        contentSearchFeed.hasMore,
+        contentSearchFeed.loadMore,
+        contentSearchFeed.loading,
+        contentSearchFeed.loadingMore,
+      ]
+    : sdkFeed;
+
+  const { error, prependPost, retry } = useContentSearch
+    ? contentSearchFeed
+    : { error: null, prependPost: () => {}, retry: () => {} };
+
   const [communities, hasMoreCommunities, loadMoreCommunities] = useCommunitiesList(
     queryParams,
     false,
     () => !showPostCreator && !enablePostTargetPicker,
   );
 
-  const renderLoadingSkeleton = () => {
-    return new Array(3).fill(3).map((x, index) => <DefaultPostRenderer key={index} loading />);
+  const handlePostCreated = (postId) => {
+    if (useContentSearch) {
+      prependPost(postId);
+    }
+
+    onPostCreated?.(postId);
   };
 
-  const onNextPage = () => {
-    setPage(page + 1);
-    loadMore();
-  };
-
-  if (!loading && !hasMore && posts.length === 0) {
-    return <></>;
+  if (isHideWhenEmpty && useContentSearch && !loading && !error && !hasMore && posts.length === 0) {
+    return null;
   }
 
+  const showEmptyFeed = !loading && !error && posts.length === 0;
+  const containerClassName =
+    useContentSearch && (posts.length > 0 || loading)
+      ? `show-padding ${className || ''}`
+      : className;
+
+  const getVisiblePosts = () => {
+    if (useContentSearch) {
+      return posts;
+    }
+
+    if (targetType === PostTargetType.GlobalFeed) {
+      return [...posts].sort((a, b) => b.createdAt - a.createdAt);
+    }
+
+    return posts
+      .filter((post) => post.postedUserId === targetId)
+      .sort((a, b) => b.createdAt - a.createdAt);
+  };
+
   return (
-    <FeedScrollContainer
-      className={posts.length > 0 || loading ? `show-padding ${className}` : className}
-      dataLength={posts.length}
-    >
+    <FeedScrollContainer className={containerClassName} dataLength={posts.length}>
       <ConditionalRender condition={!isHiddenProfile}>
-        <>
-          {showPostCreator && (
-            <PostCreator
-              data-qa-anchor="feed-post-creator-textarea"
-              targetType={targetType}
-              targetId={targetId}
-              communities={communities}
-              enablePostTargetPicker={enablePostTargetPicker}
-              hasMoreCommunities={hasMoreCommunities}
-              loadMoreCommunities={loadMoreCommunities}
-              onCreateSuccess={onPostCreated}
-            />
-          )}
+        {showPostCreator && (
+          <PostCreator
+            data-qa-anchor="feed-post-creator-textarea"
+            targetType={targetType}
+            targetId={targetId}
+            communities={communities}
+            enablePostTargetPicker={enablePostTargetPicker}
+            hasMoreCommunities={hasMoreCommunities}
+            loadMoreCommunities={loadMoreCommunities}
+            onCreateSuccess={handlePostCreated}
+          />
+        )}
 
-          {loading && renderLoadingSkeleton()}
+        {loading && renderLoadingSkeleton()}
 
-          {posts.length > 0 && (
-            <LoadMore
-              hasMore={hasMore && !loadingMore}
-              loadMore={onNextPage}
-              className="load-more no-border"
-            >
-              {posts.map(({ postId }) => (
-                <Post
-                  key={postId}
-                  postId={postId}
-                  hidePostTarget={true}
-                  readonly={readonly}
-                  showOptionMenu={showOptionMenu}
-                />
-              ))}
-              {loadingMore && renderLoadingSkeleton()}
-            </LoadMore>
-          )}
-        </>
+        {error && (
+          <FeedError>
+            <p>{error}</p>
+            <button type="button" onClick={retry}>
+              Retry
+            </button>
+          </FeedError>
+        )}
+
+        {!loading &&
+          posts.length > 0 &&
+          !useContentSearch &&
+          targetType !== PostTargetType.GlobalFeed &&
+          posts.filter((post) => post.postedUserId === targetId).length < 10 &&
+          hasMore &&
+          loadMore()}
+
+        {!loading && posts.length > 0 && (
+          <LoadMore
+            hasMore={hasMore && !loadingMore}
+            loadMore={loadMore}
+            className="load-more no-border"
+          >
+            {getVisiblePosts().map(({ postId }) => (
+              <Post
+                key={postId}
+                postId={postId}
+                hidePostTarget
+                readonly={readonly}
+                showOptionMenu={showOptionMenu}
+              />
+            ))}
+            {loadingMore && renderLoadingSkeleton()}
+          </LoadMore>
+        )}
+
+        {showEmptyFeed && (
+          <EmptyFeed
+            targetType={targetType}
+            goToExplore={goToExplore}
+            canPost={showPostCreator}
+            feedType={feedType}
+          />
+        )}
         <PrivateFeed />
       </ConditionalRender>
     </FeedScrollContainer>
@@ -122,11 +188,13 @@ Feed.propTypes = {
   targetId: PropTypes.string,
   searchType: PropTypes.string,
   showTargetId: PropTypes.string,
+  useContentSearch: PropTypes.bool,
   showPostCreator: PropTypes.bool,
   goToExplore: PropTypes.func,
   readonly: PropTypes.bool,
   isHiddenProfile: PropTypes.bool,
   showOptionMenu: PropTypes.bool,
+  isHideWhenEmpty: PropTypes.bool,
   onPostCreated: PropTypes.func,
 };
 

--- a/src/social/components/Feed/index.js
+++ b/src/social/components/Feed/index.js
@@ -1,19 +1,24 @@
-import React, { memo } from 'react';
+import React, { memo, useState } from 'react';
 import PropTypes from 'prop-types';
 import { PostTargetType, FeedType, CommunityFilter } from '@amityco/js-sdk';
-import DefaultPostRenderer from '~/social/components/post/Post/DefaultPostRenderer';
 
+import { useSDK } from '~/core/hooks/useSDK';
 import useCommunitiesList from '~/social/hooks/useCommunitiesList';
+import useSearchFeed from '~/social/hooks/useSearchFeed';
+
+import customizableComponent from '~/core/hocs/customization';
+
+import DefaultPostRenderer from '~/social/components/post/Post/DefaultPostRenderer';
 import PostCreator from '~/social/components/post/Creator';
 import Post from '~/social/components/post/Post';
-import customizableComponent from '~/core/hocs/customization';
 import ConditionalRender from '~/core/components/ConditionalRender';
-import EmptyFeed from '~/social/components/EmptyFeed';
 import LoadMore from '~/social/components/LoadMore';
-import useFeed from '~/social/hooks/useFeed';
-import { FeedScrollContainer } from './styles';
 import PrivateFeed from '~/social/components/PrivateFeed';
 
+import { FeedScrollContainer } from './styles';
+
+const defaultNumber = 10;
+const perPageNumber = 10;
 const queryParams = { filter: CommunityFilter.Member };
 
 const Feed = ({
@@ -21,18 +26,28 @@ const Feed = ({
   feedType,
   targetType = PostTargetType.MyFeed,
   targetId = '',
+  searchType,
+  showTargetId,
   showPostCreator = false,
   onPostCreated,
   goToExplore,
   readonly = false,
   isHiddenProfile = false,
+  showOptionMenu,
 }) => {
-  const enablePostTargetPicker = false;
+  const { currentUserId } = useSDK();
 
-  const [posts, hasMore, loadMore, loading, loadingMore] = useFeed({
+  const enablePostTargetPicker = false;
+  const [page, setPage] = useState(1);
+
+  const [posts, hasMore, loadMore, loading, loadingMore] = useSearchFeed({
     targetType,
     targetId,
-    feedType,
+    loginUserId: currentUserId,
+    searchType,
+    showTargetId,
+    defaultNumber,
+    queryLimit: perPageNumber,
   });
   const [communities, hasMoreCommunities, loadMoreCommunities] = useCommunitiesList(
     queryParams,
@@ -40,16 +55,23 @@ const Feed = ({
     () => !showPostCreator && !enablePostTargetPicker,
   );
 
-  function renderLoadingSkeleton() {
+  const renderLoadingSkeleton = () => {
     return new Array(3).fill(3).map((x, index) => <DefaultPostRenderer key={index} loading />);
+  };
+
+  const onNextPage = () => {
+    setPage(page + 1);
+    loadMore();
+  };
+
+  if (!loading && !hasMore && posts.length === 0) {
+    return <></>;
   }
 
   return (
     <FeedScrollContainer
-      className={className}
+      className={posts.length > 0 || loading ? `show-padding ${className}` : className}
       dataLength={posts.length}
-      next={loadMore}
-      hasMore={hasMore}
     >
       <ConditionalRender condition={!isHiddenProfile}>
         <>
@@ -68,41 +90,23 @@ const Feed = ({
 
           {loading && renderLoadingSkeleton()}
 
-          {!loading && posts.length > 0 && targetType !== PostTargetType.GlobalFeed && 
-              posts.filter((post) => post.postedUserId === targetId).length < 10 && hasMore && loadMore()}
-                  
-
-          {!loading && posts.length > 0 && (
-            <LoadMore hasMore={hasMore} loadMore={loadMore} className="load-more no-border">
-              {targetType !== PostTargetType.GlobalFeed && posts.filter((post) => post.postedUserId === targetId).
-              sort((a, b) => b.createdAt - a.createdAt).map(({ postId }) => (
-                <Post
-                    key={postId}
-                    postId={postId}
-                    hidePostTarget={true}
-                    readonly={readonly}
-                />
-                ))}
-              
-              {targetType === PostTargetType.GlobalFeed && posts.sort((a, b) => b.createdAt - a.createdAt).map(({ postId }) => (
+          {posts.length > 0 && (
+            <LoadMore
+              hasMore={hasMore && !loadingMore}
+              loadMore={onNextPage}
+              className="load-more no-border"
+            >
+              {posts.map(({ postId }) => (
                 <Post
                   key={postId}
                   postId={postId}
                   hidePostTarget={true}
                   readonly={readonly}
+                  showOptionMenu={showOptionMenu}
                 />
               ))}
               {loadingMore && renderLoadingSkeleton()}
             </LoadMore>
-          )}
-
-          {!loading && posts.length === 0 && (
-            <EmptyFeed
-              targetType={targetType}
-              goToExplore={goToExplore}
-              canPost={showPostCreator}
-              feedType={feedType}
-            />
           )}
         </>
         <PrivateFeed />
@@ -116,11 +120,13 @@ Feed.propTypes = {
   feedType: PropTypes.oneOf(Object.values(FeedType)),
   targetType: PropTypes.oneOf(Object.values(PostTargetType)),
   targetId: PropTypes.string,
+  searchType: PropTypes.string,
+  showTargetId: PropTypes.string,
   showPostCreator: PropTypes.bool,
-  // below is to be refactored
   goToExplore: PropTypes.func,
   readonly: PropTypes.bool,
   isHiddenProfile: PropTypes.bool,
+  showOptionMenu: PropTypes.bool,
   onPostCreated: PropTypes.func,
 };
 

--- a/src/social/components/Feed/styles.js
+++ b/src/social/components/Feed/styles.js
@@ -53,3 +53,23 @@ export const PrivateFeedBody = styled.div`
   font-size: 14px;
   color: ${({ theme }) => theme.palette.base.shade1};
 `;
+
+export const FeedError = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 24px 16px;
+  text-align: center;
+  color: ${({ theme }) => theme.palette.base.main};
+  ${({ theme }) => theme.typography.body};
+
+  button {
+    cursor: pointer;
+    border: 1px solid ${({ theme }) => theme.palette.primary.main};
+    background: transparent;
+    color: ${({ theme }) => theme.palette.primary.main};
+    border-radius: 4px;
+    padding: 8px 16px;
+  }
+`;

--- a/src/social/hooks/useSearchFeed.js
+++ b/src/social/hooks/useSearchFeed.js
@@ -1,0 +1,155 @@
+import { useCallback, useEffect, useState } from 'react';
+import { PostTargetType } from '@amityco/js-sdk';
+
+import {
+  AMITY_API_KEY,
+  AMITY_GLOBAL_CATEGORY_ID,
+  BBVR_GLOBAL_COMMUNITY_ID,
+  CONTENT_SEARCH_API_URL,
+} from '~/constants';
+
+const COMMUNITY_TARGET_TYPE = 'community';
+
+const resolveSearchParams = ({ targetType, targetId, searchType, showTargetId }) => {
+  if (searchType) {
+    return {
+      targetType: COMMUNITY_TARGET_TYPE,
+      targetId: BBVR_GLOBAL_COMMUNITY_ID,
+      searchType,
+      showTargetId,
+    };
+  }
+
+  if (targetType === PostTargetType.UserFeed || targetType === PostTargetType.MyFeed) {
+    return {
+      targetType: COMMUNITY_TARGET_TYPE,
+      targetId: BBVR_GLOBAL_COMMUNITY_ID,
+      searchType: 'user',
+      showTargetId: targetId,
+    };
+  }
+
+  if (targetType === PostTargetType.GlobalFeed || targetType === PostTargetType.CommunityFeed) {
+    return {
+      targetType: COMMUNITY_TARGET_TYPE,
+      targetId: targetId || BBVR_GLOBAL_COMMUNITY_ID,
+    };
+  }
+
+  return {
+    targetType: targetType || COMMUNITY_TARGET_TYPE,
+    targetId: targetId || BBVR_GLOBAL_COMMUNITY_ID,
+  };
+};
+
+const useSearchFeed = ({
+  targetType,
+  targetId,
+  loginUserId,
+  searchType,
+  showTargetId,
+  queryLimit,
+  defaultNumber,
+}) => {
+  const [page, setPage] = useState(0);
+  const [data, setData] = useState([]);
+  const [hasMore, setHasMore] = useState(true);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+
+  const fetchData = useCallback(
+    async (currentPage) => {
+      const {
+        targetType: resolvedTargetType,
+        targetId: resolvedTargetId,
+        searchType: resolvedSearchType,
+        showTargetId: resolvedShowTargetId,
+      } = resolveSearchParams({ targetType, targetId, searchType, showTargetId });
+
+      const pageSize = currentPage === 0 ? defaultNumber : queryLimit;
+      const query = {
+        apiKey: AMITY_API_KEY,
+        userId: loginUserId,
+        categoryId: AMITY_GLOBAL_CATEGORY_ID,
+        from: currentPage === 0 ? 0 : (currentPage - 1) * queryLimit + defaultNumber,
+        size: pageSize,
+        query: {
+          targetId: [resolvedTargetId],
+          targetType: resolvedTargetType,
+        },
+        sort: [
+          {
+            createdAt: {
+              order: 'desc',
+            },
+          },
+        ],
+      };
+
+      if (resolvedSearchType === 'user') {
+        query.query.postedUserId = resolvedShowTargetId;
+      } else if (resolvedSearchType === 'team') {
+        query.query.metadata = { team_id: resolvedShowTargetId };
+      } else if (resolvedSearchType === 'gym') {
+        query.query.metadata = { gym_id: resolvedShowTargetId };
+      } else if (resolvedSearchType === 'gem') {
+        query.query.metadata = { type: 'unityGemItemPurchased,unityGemsEarned' };
+      }
+
+      const response = await fetch(CONTENT_SEARCH_API_URL, {
+        method: 'POST',
+        body: JSON.stringify(query),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+
+      const result = await response.json();
+      const newData = (result?.postIds || []).map((id) => ({ postId: id }));
+
+      setHasMore(newData.length === pageSize);
+
+      if (currentPage === 0) {
+        setData(newData);
+      } else {
+        setData((prev) => [...prev, ...newData]);
+      }
+    },
+    [defaultNumber, loginUserId, queryLimit, searchType, showTargetId, targetId, targetType],
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function init() {
+      setLoading(true);
+      setPage(0);
+      setHasMore(true);
+      await fetchData(0);
+
+      if (!cancelled) {
+        setLoading(false);
+      }
+    }
+
+    if (loginUserId) {
+      init();
+    }
+
+    return () => {
+      cancelled = true;
+    };
+  }, [fetchData, loginUserId]);
+
+  const loadMore = async () => {
+    const newPage = page + 1;
+    setLoadingMore(true);
+    setPage(newPage);
+    await fetchData(newPage);
+    setLoadingMore(false);
+  };
+
+  return [data, hasMore, loadMore, loading, loadingMore];
+};
+
+export default useSearchFeed;

--- a/src/social/hooks/useSearchFeed.js
+++ b/src/social/hooks/useSearchFeed.js
@@ -50,12 +50,14 @@ const useSearchFeed = ({
   showTargetId,
   queryLimit,
   defaultNumber,
+  enabled = true,
 }) => {
   const [page, setPage] = useState(0);
   const [data, setData] = useState([]);
   const [hasMore, setHasMore] = useState(true);
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
+  const [error, setError] = useState(null);
 
   const fetchData = useCallback(
     async (currentPage) => {
@@ -96,60 +98,140 @@ const useSearchFeed = ({
         query.query.metadata = { type: 'unityGemItemPurchased,unityGemsEarned' };
       }
 
-      const response = await fetch(CONTENT_SEARCH_API_URL, {
-        method: 'POST',
-        body: JSON.stringify(query),
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      });
+      try {
+        const response = await fetch(CONTENT_SEARCH_API_URL, {
+          method: 'POST',
+          body: JSON.stringify(query),
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
 
-      const result = await response.json();
-      const newData = (result?.postIds || []).map((id) => ({ postId: id }));
+        if (!response.ok) {
+          throw new Error(`Content search failed (${response.status})`);
+        }
 
-      setHasMore(newData.length === pageSize);
+        const result = await response.json();
 
-      if (currentPage === 0) {
-        setData(newData);
-      } else {
-        setData((prev) => [...prev, ...newData]);
+        if (!result?.success) {
+          throw new Error(result?.message || 'Content search failed');
+        }
+
+        const newData = (result?.postIds || []).map((id) => ({ postId: id }));
+
+        setError(null);
+        setHasMore(newData.length === pageSize);
+
+        if (currentPage === 0) {
+          setData(newData);
+        } else {
+          setData((prev) => [...prev, ...newData]);
+        }
+
+        return true;
+      } catch (err) {
+        setError(err?.message || 'Failed to load feed');
+
+        if (currentPage === 0) {
+          setData([]);
+        }
+
+        setHasMore(false);
+        return false;
       }
     },
     [defaultNumber, loginUserId, queryLimit, searchType, showTargetId, targetId, targetType],
   );
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    setPage(0);
+    setHasMore(true);
+
+    try {
+      await fetchData(0);
+    } finally {
+      setLoading(false);
+    }
+  }, [fetchData]);
+
+  const prependPost = useCallback((postId) => {
+    if (!postId) return;
+
+    setData((prev) => {
+      if (prev.some((post) => post.postId === postId)) {
+        return prev;
+      }
+
+      return [{ postId }, ...prev];
+    });
+    setError(null);
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
 
     async function init() {
       setLoading(true);
+      setError(null);
       setPage(0);
       setHasMore(true);
-      await fetchData(0);
 
-      if (!cancelled) {
-        setLoading(false);
+      try {
+        await fetchData(0);
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
       }
+    }
+
+    if (!enabled) {
+      setLoading(false);
+      setLoadingMore(false);
+      setError(null);
+      setData([]);
+      setHasMore(false);
+      return undefined;
     }
 
     if (loginUserId) {
       init();
+    } else {
+      setLoading(false);
+      setData([]);
+      setHasMore(false);
     }
 
     return () => {
       cancelled = true;
     };
-  }, [fetchData, loginUserId]);
+  }, [enabled, fetchData, loginUserId]);
 
-  const loadMore = async () => {
+  const loadMore = useCallback(async () => {
     const newPage = page + 1;
     setLoadingMore(true);
-    setPage(newPage);
-    await fetchData(newPage);
-    setLoadingMore(false);
-  };
 
-  return [data, hasMore, loadMore, loading, loadingMore];
+    try {
+      setPage(newPage);
+      await fetchData(newPage);
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [fetchData, page]);
+
+  return {
+    posts: data,
+    hasMore,
+    loadMore,
+    loading,
+    loadingMore,
+    error,
+    refresh,
+    prependPost,
+    retry: refresh,
+  };
 };
 
 export default useSearchFeed;

--- a/src/social/hooks/useSearchFeed.js
+++ b/src/social/hooks/useSearchFeed.js
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { PostTargetType } from '@amityco/js-sdk';
 
 import {
@@ -10,7 +10,7 @@ import {
 
 const COMMUNITY_TARGET_TYPE = 'community';
 
-const resolveSearchParams = ({ targetType, targetId, searchType, showTargetId }) => {
+const resolveSearchParams = ({ targetType, targetId, searchType, showTargetId, loginUserId }) => {
   if (searchType) {
     return {
       targetType: COMMUNITY_TARGET_TYPE,
@@ -25,7 +25,7 @@ const resolveSearchParams = ({ targetType, targetId, searchType, showTargetId })
       targetType: COMMUNITY_TARGET_TYPE,
       targetId: BBVR_GLOBAL_COMMUNITY_ID,
       searchType: 'user',
-      showTargetId: targetId,
+      showTargetId: targetId || (targetType === PostTargetType.MyFeed ? loginUserId : ''),
     };
   }
 
@@ -58,15 +58,27 @@ const useSearchFeed = ({
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState(null);
+  const abortControllerRef = useRef(null);
+
+  const abortInflightRequest = useCallback(() => {
+    abortControllerRef.current?.abort();
+    abortControllerRef.current = null;
+  }, []);
 
   const fetchData = useCallback(
     async (currentPage) => {
+      abortInflightRequest();
+
+      const controller = new AbortController();
+      abortControllerRef.current = controller;
+      const { signal } = controller;
+
       const {
         targetType: resolvedTargetType,
         targetId: resolvedTargetId,
         searchType: resolvedSearchType,
         showTargetId: resolvedShowTargetId,
-      } = resolveSearchParams({ targetType, targetId, searchType, showTargetId });
+      } = resolveSearchParams({ targetType, targetId, searchType, showTargetId, loginUserId });
 
       const pageSize = currentPage === 0 ? defaultNumber : queryLimit;
       const query = {
@@ -105,13 +117,22 @@ const useSearchFeed = ({
           headers: {
             'Content-Type': 'application/json',
           },
+          signal,
         });
+
+        if (signal.aborted) {
+          return false;
+        }
 
         if (!response.ok) {
           throw new Error(`Content search failed (${response.status})`);
         }
 
         const result = await response.json();
+
+        if (signal.aborted) {
+          return false;
+        }
 
         if (!result?.success) {
           throw new Error(result?.message || 'Content search failed');
@@ -130,6 +151,10 @@ const useSearchFeed = ({
 
         return true;
       } catch (err) {
+        if (err?.name === 'AbortError' || signal.aborted) {
+          return false;
+        }
+
         setError(err?.message || 'Failed to load feed');
 
         if (currentPage === 0) {
@@ -138,9 +163,22 @@ const useSearchFeed = ({
 
         setHasMore(false);
         return false;
+      } finally {
+        if (abortControllerRef.current === controller) {
+          abortControllerRef.current = null;
+        }
       }
     },
-    [defaultNumber, loginUserId, queryLimit, searchType, showTargetId, targetId, targetType],
+    [
+      abortInflightRequest,
+      defaultNumber,
+      loginUserId,
+      queryLimit,
+      searchType,
+      showTargetId,
+      targetId,
+      targetType,
+    ],
   );
 
   const refresh = useCallback(async () => {
@@ -170,7 +208,25 @@ const useSearchFeed = ({
   }, []);
 
   useEffect(() => {
-    let cancelled = false;
+    if (!enabled) {
+      abortInflightRequest();
+      setLoading(false);
+      setLoadingMore(false);
+      setError(null);
+      setData([]);
+      setHasMore(false);
+      return undefined;
+    }
+
+    if (!loginUserId) {
+      abortInflightRequest();
+      setLoading(false);
+      setData([]);
+      setHasMore(false);
+      return undefined;
+    }
+
+    let active = true;
 
     async function init() {
       setLoading(true);
@@ -181,33 +237,19 @@ const useSearchFeed = ({
       try {
         await fetchData(0);
       } finally {
-        if (!cancelled) {
+        if (active) {
           setLoading(false);
         }
       }
     }
 
-    if (!enabled) {
-      setLoading(false);
-      setLoadingMore(false);
-      setError(null);
-      setData([]);
-      setHasMore(false);
-      return undefined;
-    }
-
-    if (loginUserId) {
-      init();
-    } else {
-      setLoading(false);
-      setData([]);
-      setHasMore(false);
-    }
+    init();
 
     return () => {
-      cancelled = true;
+      active = false;
+      abortInflightRequest();
     };
-  }, [enabled, fetchData, loginUserId]);
+  }, [abortInflightRequest, enabled, fetchData, loginUserId]);
 
   const loadMore = useCallback(async () => {
     const newPage = page + 1;

--- a/src/social/hooks/useSearchFeed.js
+++ b/src/social/hooks/useSearchFeed.js
@@ -59,6 +59,7 @@ const useSearchFeed = ({
   const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState(null);
   const abortControllerRef = useRef(null);
+  const mountedRef = useRef(true);
 
   const abortInflightRequest = useCallback(() => {
     abortControllerRef.current?.abort();
@@ -182,6 +183,10 @@ const useSearchFeed = ({
   );
 
   const refresh = useCallback(async () => {
+    if (!mountedRef.current) {
+      return;
+    }
+
     setLoading(true);
     setError(null);
     setPage(0);
@@ -190,7 +195,9 @@ const useSearchFeed = ({
     try {
       await fetchData(0);
     } finally {
-      setLoading(false);
+      if (mountedRef.current) {
+        setLoading(false);
+      }
     }
   }, [fetchData]);
 
@@ -206,6 +213,15 @@ const useSearchFeed = ({
     });
     setError(null);
   }, []);
+
+  useEffect(() => {
+    mountedRef.current = true;
+
+    return () => {
+      mountedRef.current = false;
+      abortInflightRequest();
+    };
+  }, [abortInflightRequest]);
 
   useEffect(() => {
     if (!enabled) {
@@ -237,7 +253,7 @@ const useSearchFeed = ({
       try {
         await fetchData(0);
       } finally {
-        if (active) {
+        if (active && mountedRef.current) {
           setLoading(false);
         }
       }
@@ -252,6 +268,10 @@ const useSearchFeed = ({
   }, [abortInflightRequest, enabled, fetchData, loginUserId]);
 
   const loadMore = useCallback(async () => {
+    if (!mountedRef.current) {
+      return;
+    }
+
     const newPage = page + 1;
     setLoadingMore(true);
 
@@ -259,7 +279,9 @@ const useSearchFeed = ({
       setPage(newPage);
       await fetchData(newPage);
     } finally {
-      setLoadingMore(false);
+      if (mountedRef.current) {
+        setLoadingMore(false);
+      }
     }
   }, [fetchData, page]);
 

--- a/src/social/pages/NewsFeed/index.js
+++ b/src/social/pages/NewsFeed/index.js
@@ -1,18 +1,16 @@
-import React, { forwardRef } from 'react';
+import React from 'react';
 import { PostTargetType } from '@amityco/js-sdk';
 
 import { BBVR_GLOBAL_COMMUNITY_ID } from '~/constants';
-import { PageTypes } from '~/social/constants';
 import Feed from '~/social/components/Feed';
-
+import { PageTypes } from '~/social/constants';
 import { useNavigation } from '~/social/providers/NavigationProvider';
 
 import { Wrapper } from './styles';
 import { BackButton, Header, Title } from '~/social/pages/CategoryCommunities/styles';
 import ArrowLeft from '~/icons/ArrowLeft';
-import PropTypes from 'prop-types';
 
-const NewsFeed = forwardRef(({ isLandingPage }, ref) => {
+const NewsFeed = () => {
   const { onBack, lastPage, onChangePage } = useNavigation();
 
   return (
@@ -22,10 +20,11 @@ const NewsFeed = forwardRef(({ isLandingPage }, ref) => {
           <BackButton onClick={onBack}>
             <ArrowLeft height={14} />
           </BackButton>
-          <Title>{'Search & Communities'}</Title>
+          <Title>Search & Communities</Title>
         </Header>
       )}
       <Feed
+        useContentSearch
         targetType={PostTargetType.CommunityFeed}
         targetId={BBVR_GLOBAL_COMMUNITY_ID}
         goToExplore={() => onChangePage(PageTypes.Explore)}
@@ -33,10 +32,6 @@ const NewsFeed = forwardRef(({ isLandingPage }, ref) => {
       />
     </Wrapper>
   );
-});
-
-NewsFeed.propTypes = {
-  isLandingPage: PropTypes.bool,
 };
 
 export default NewsFeed;

--- a/src/social/pages/NewsFeed/index.js
+++ b/src/social/pages/NewsFeed/index.js
@@ -1,6 +1,7 @@
 import React, { forwardRef } from 'react';
 import { PostTargetType } from '@amityco/js-sdk';
 
+import { BBVR_GLOBAL_COMMUNITY_ID } from '~/constants';
 import { PageTypes } from '~/social/constants';
 import Feed from '~/social/components/Feed';
 
@@ -25,7 +26,8 @@ const NewsFeed = forwardRef(({ isLandingPage }, ref) => {
         </Header>
       )}
       <Feed
-        targetType={PostTargetType.GlobalFeed}
+        targetType={PostTargetType.CommunityFeed}
+        targetId={BBVR_GLOBAL_COMMUNITY_ID}
         goToExplore={() => onChangePage(PageTypes.Explore)}
         showPostCreator
       />


### PR DESCRIPTION
## Summary

- Replaces the Amity SDK live feed (`useFeed` → `PostRepository.queryAllPosts` + WebSocket subscriptions) with the **content-search REST API** for the **Unity main feed only** (`NewsFeed` via new `useContentSearch` prop).
- Points the Unity main feed (`?type=feed`) at the **BBVR global community** (`64af01593714fddb10e0c7d2`) and returns **all community member posts**, sorted `createdAt desc` (newest first).
- **Does not change team chat** or other `Feed` surfaces (`UserFeed`, `CommunityFeed`, pending review tabs) — those keep the existing SDK `useFeed` path.

## Problem (for future AI agents)

Around June 2026, the Unity social feed at:

```
https://social.vrfr.io/?type=feed&userId=5cb20e57c7a3f404ff343783&username=Ryan&auth=
```

stopped showing new posts. Browser console showed repeated:

```
ASCWebSDK: RateLimit Exceeded
ASCError: RateLimit Exceeded
```

Meanwhile, feeds on `community.blackbox-vr.com` (the `bbvr-social` repo) continued to work.

### Root cause

These are **two different deployments** with **two different feed data paths**:

| Deployment | URL | Feed mechanism |
|------------|-----|----------------|
| Unity webview | `social.vrfr.io` | Standalone UI kit + `useFeed` → Amity SDK `queryAllPosts` + live WebSocket collection |
| Community website | `community.blackbox-vr.com` | Vendored UI kit copy inside `bbvr-social` + `useSearchFeed` → content-search API |

The SDK path is chatty (live collections, subscriptions, reconnects). Every Unity client shares the same service-account `userId` (`5cb20e57c7a3f404ff343783`), which amplifies API usage. Amity/Social+ rate-limited the SDK feed calls. The content-search API was unaffected.

### Infrastructure context

- `social.vrfr.io` → Route53 → ALB `prod-bbvr-socialFeed` → ECS Fargate → ECR image `bbvr-social`
- Shell app: `bbvr-social` branch `_social-feed-uikit-update-attempt-2`, file `src/App.js` (query-param router)
- UI kit consumed as `file:package.tgz` built from **this repo**

## Solution

Port the working `useSearchFeed` pattern from the vendored `bbvr-social/Amity-Social-Cloud-UIKit-Web-OpenSource` copy into this standalone repo, but **scope it to `NewsFeed` only** via a `useContentSearch` prop on `Feed`.

### Files changed

1. **`src/constants/index.js`** — Added `AMITY_API_KEY`, `AMITY_GLOBAL_CATEGORY_ID`, `BBVR_GLOBAL_COMMUNITY_ID`, `CONTENT_SEARCH_API_URL`.
2. **`src/social/hooks/useSearchFeed.js`** (new) — Fetches post IDs via content-search API with `enabled` gating, error handling, `refresh`/`retry`, and `prependPost(postId)` for immediate post-create updates.
3. **`src/social/components/Feed/index.js`** — Adds `useContentSearch` prop. When `false` (default), preserves existing SDK `useFeed` behavior for `UserFeed`, `CommunityFeed`, pending review, etc. When `true` (Unity `NewsFeed`), uses content search. Restores `EmptyFeed` and optional `isHideWhenEmpty` blank behavior.
4. **`src/social/components/Feed/styles.js`** — Adds `FeedError` retry UI for content-search failures.
5. **`src/social/pages/NewsFeed/index.js`** — Enables `useContentSearch` with `CommunityFeed` + `BBVR_GLOBAL_COMMUNITY_ID`.
6. **`.github/workflows/*.yaml`** — Bumps deprecated `actions/cache@v2` → `v4`.

### Review feedback addressed

- [x] **P1:** New posts appear immediately via `prependPost` in `handlePostCreated`.
- [x] **P1:** Content-search failures surface error + Retry; `loading`/`loadingMore` cleared in `finally`.
- [x] **P2:** Empty feeds restore `PostCreator` + `EmptyFeed` (blank-only behavior gated behind `isHideWhenEmpty`).
- [x] **P2:** Content search scoped to `NewsFeed` via `useContentSearch`; other feed surfaces keep SDK `useFeed` + `feedType` semantics.
- [x] **P2:** Touched-file eslint issues fixed.
- [x] **CI:** Workflow cache action updated to v4.

## Team chat is NOT affected

Unity routes modes by `?type=` query param in `bbvr-social` `src/App.js`:

| `type` param | Component | Touched by this PR? |
|--------------|-----------|---------------------|
| `feed` | `AmityUiKitSocial` → NewsFeed → **Feed (`useContentSearch`)** | **Yes** |
| `search` | `AmityUiKitSocial` | No |
| `chatsearch` | `AmityUiKitSocial` | No |
| `post` | `AmityUiKitSocial` | No |
| `teamChat` | `AmityUiKitChat` (`membershipFilter="member"`) | **No** |
| `chat` | `AmityUiKitChat` (1:1 DM) | **No** |

## Deploy instructions (after merge)

```bash
cd Amity-Social-Cloud-UIKit-Web-OpenSource
npm ci && npm run build && npm pack

cd bbvr-social   # branch: _social-feed-uikit-update-attempt-2
cp ../Amity-Social-Cloud-UIKit-Web-OpenSource/amityco-ui-kit-open-source-*.tgz ./package.tgz
npm run build
# docker build → ECR push → ECS deploy (existing pipeline)
```

## Test plan

- [x] `npm ci`
- [x] `npm test -- --runInBand --watch=false`
- [x] `npx eslint` on touched files
- [ ] `npm run build` after merge (webpack bundle-size warnings pre-exist)
- [ ] Deploy to `social.dev.vrfr.io` staging
- [ ] Open `?type=feed&userId=...&username=Ryan&auth=...` — no `RateLimit Exceeded` errors
- [ ] Network tab shows `POST beta.amity.services/search/v2/posts`
- [ ] New community posts appear newest-first
- [ ] Create a post from the feed composer — appears immediately without reload
- [ ] Simulate search API failure — error + Retry renders, no infinite skeleton
- [ ] Empty community feed — composer + `EmptyFeed` visible
- [ ] `?type=teamChat` — team chat still works
- [ ] `?type=chat&secondUserId=...` — 1:1 DM still works
- [ ] `UserFeed` / `CommunityFeed` pages still use SDK feed path

## Follow-up recommendations (not in this PR)

- Pass per-player `userId` + real `auth` token from Unity instead of the shared service account.
- Consider requesting a Social+ rate-limit review if SDK paths remain in use elsewhere.
- Align vendored `bbvr-social` UI kit copy and this standalone repo to reduce drift.