### PR TITLE
fix(feed): ASC-000 - Render Unity content search results

### DIFF
--- a/src/social/components/Feed/index.js
+++ b/src/social/components/Feed/index.js
@@ -91,65 +91,67 @@ const FeedBody = ({
   return (
     <FeedScrollContainer className={containerClassName} dataLength={posts.length}>
       <ConditionalRender condition={!isHiddenProfile}>
-        {showPostCreator && (
-          <PostCreator
-            data-qa-anchor="feed-post-creator-textarea"
-            targetType={targetType}
-            targetId={targetId}
-            communities={communities}
-            enablePostTargetPicker={enablePostTargetPicker}
-            hasMoreCommunities={hasMoreCommunities}
-            loadMoreCommunities={loadMoreCommunities}
-            onCreateSuccess={handlePostCreated}
-          />
-        )}
+        <>
+          {showPostCreator && (
+            <PostCreator
+              data-qa-anchor="feed-post-creator-textarea"
+              targetType={targetType}
+              targetId={targetId}
+              communities={communities}
+              enablePostTargetPicker={enablePostTargetPicker}
+              hasMoreCommunities={hasMoreCommunities}
+              loadMoreCommunities={loadMoreCommunities}
+              onCreateSuccess={handlePostCreated}
+            />
+          )}
 
-        {loading && renderLoadingSkeleton()}
+          {loading && renderLoadingSkeleton()}
 
-        {error && (
-          <FeedError>
-            <p>{error}</p>
-            <button type="button" onClick={retry}>
-              Retry
-            </button>
-          </FeedError>
-        )}
+          {error && (
+            <FeedError>
+              <p>{error}</p>
+              <button type="button" onClick={retry}>
+                Retry
+              </button>
+            </FeedError>
+          )}
 
-        {!loading &&
-          posts.length > 0 &&
-          !useContentSearch &&
-          targetType !== PostTargetType.GlobalFeed &&
-          posts.filter((post) => post.postedUserId === targetId).length < 10 &&
-          hasMore &&
-          loadMore()}
+          {!loading &&
+            posts.length > 0 &&
+            !useContentSearch &&
+            targetType !== PostTargetType.GlobalFeed &&
+            posts.filter((post) => post.postedUserId === targetId).length < 10 &&
+            hasMore &&
+            loadMore()}
 
-        {!loading && posts.length > 0 && (
-          <LoadMore
-            hasMore={hasMore && !loadingMore}
-            loadMore={loadMore}
-            className="load-more no-border"
-          >
-            {getVisiblePosts().map(({ postId }) => (
-              <Post
-                key={postId}
-                postId={postId}
-                hidePostTarget
-                readonly={readonly}
-                showOptionMenu={showOptionMenu}
-              />
-            ))}
-            {loadingMore && renderLoadingSkeleton()}
-          </LoadMore>
-        )}
+          {posts.length > 0 && (
+            <LoadMore
+              hasMore={hasMore && !loadingMore}
+              loadMore={loadMore}
+              className="load-more no-border"
+            >
+              {getVisiblePosts().map(({ postId }) => (
+                <Post
+                  key={postId}
+                  postId={postId}
+                  hidePostTarget
+                  readonly={readonly}
+                  showOptionMenu={showOptionMenu}
+                />
+              ))}
+              {loadingMore && renderLoadingSkeleton()}
+            </LoadMore>
+          )}
 
-        {showEmptyFeed && (
-          <EmptyFeed
-            targetType={targetType}
-            goToExplore={goToExplore}
-            canPost={showPostCreator}
-            feedType={feedType}
-          />
-        )}
+          {showEmptyFeed && (
+            <EmptyFeed
+              targetType={targetType}
+              goToExplore={goToExplore}
+              canPost={showPostCreator}
+              feedType={feedType}
+            />
+          )}
+        </>
         <PrivateFeed />
       </ConditionalRender>
     </FeedScrollContainer>
@@ -177,14 +179,23 @@ const SdkFeed = (props) => {
   );
 };
 
+const getQueryUserId = () => {
+  if (typeof window === 'undefined') {
+    return '';
+  }
+
+  return new URLSearchParams(window.location.search).get('userId') || '';
+};
+
 const ContentSearchFeed = (props) => {
-  const { currentUserId } = useSDK();
+  const { currentUserId, client } = useSDK();
+  const loginUserId = currentUserId || client?.currentUserId || getQueryUserId();
   const { targetType, targetId, searchType, showTargetId } = props;
   const { posts, hasMore, loadMore, loading, loadingMore, error, prependPost, retry } =
     useSearchFeed({
       targetType,
       targetId,
-      loginUserId: currentUserId,
+      loginUserId,
       searchType,
       showTargetId,
       defaultNumber,

--- a/src/social/hooks/useSearchFeed.js
+++ b/src/social/hooks/useSearchFeed.js
@@ -9,6 +9,7 @@ import {
 } from '~/constants';
 
 const COMMUNITY_TARGET_TYPE = 'community';
+const FEED_DEBUG_KEY = '__BBVR_FEED_DEBUG__';
 
 const resolveSearchParams = ({ targetType, targetId, searchType, showTargetId, loginUserId }) => {
   if (searchType) {
@@ -58,22 +59,14 @@ const useSearchFeed = ({
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState(null);
-  const abortControllerRef = useRef(null);
-  const mountedRef = useRef(true);
+  const dataRef = useRef(data);
 
-  const abortInflightRequest = useCallback(() => {
-    abortControllerRef.current?.abort();
-    abortControllerRef.current = null;
-  }, []);
+  useEffect(() => {
+    dataRef.current = data;
+  }, [data]);
 
   const fetchData = useCallback(
     async (currentPage) => {
-      abortInflightRequest();
-
-      const controller = new AbortController();
-      abortControllerRef.current = controller;
-      const { signal } = controller;
-
       const {
         targetType: resolvedTargetType,
         targetId: resolvedTargetId,
@@ -111,82 +104,103 @@ const useSearchFeed = ({
         query.query.metadata = { type: 'unityGemItemPurchased,unityGemsEarned' };
       }
 
-      try {
-        const response = await fetch(CONTENT_SEARCH_API_URL, {
-          method: 'POST',
-          body: JSON.stringify(query),
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          signal,
-        });
+      const response = await fetch(CONTENT_SEARCH_API_URL, {
+        method: 'POST',
+        body: JSON.stringify(query),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
 
-        if (signal.aborted) {
-          return false;
-        }
+      if (!response.ok) {
+        throw new Error(`Content search failed (${response.status})`);
+      }
 
-        if (!response.ok) {
-          throw new Error(`Content search failed (${response.status})`);
-        }
+      const result = await response.json();
 
-        const result = await response.json();
+      if (!result?.success) {
+        throw new Error(result?.message || 'Content search failed');
+      }
 
-        if (signal.aborted) {
-          return false;
-        }
+      const newData = (result?.postIds || []).map((id) => ({ postId: id }));
 
-        if (!result?.success) {
-          throw new Error(result?.message || 'Content search failed');
-        }
+      if (typeof window !== 'undefined') {
+        window[FEED_DEBUG_KEY] = {
+          loginUserId,
+          count: newData.length,
+          ids: newData.slice(0, 3).map((post) => post.postId),
+          currentPage,
+        };
+      }
 
-        const newData = (result?.postIds || []).map((id) => ({ postId: id }));
+      setError(null);
+      setHasMore(newData.length === pageSize);
 
-        setError(null);
-        setHasMore(newData.length === pageSize);
-
-        if (currentPage === 0) {
-          setData(newData);
-        } else {
-          setData((prev) => [...prev, ...newData]);
-        }
-
-        return true;
-      } catch (err) {
-        if (err?.name === 'AbortError' || signal.aborted) {
-          return false;
-        }
-
-        setError(err?.message || 'Failed to load feed');
-
-        if (currentPage === 0) {
-          setData([]);
-        }
-
-        setHasMore(false);
-        return false;
-      } finally {
-        if (abortControllerRef.current === controller) {
-          abortControllerRef.current = null;
-        }
+      if (currentPage === 0) {
+        setData(newData);
+      } else {
+        setData([...dataRef.current, ...newData]);
       }
     },
-    [
-      abortInflightRequest,
-      defaultNumber,
-      loginUserId,
-      queryLimit,
-      searchType,
-      showTargetId,
-      targetId,
-      targetType,
-    ],
+    [defaultNumber, loginUserId, queryLimit, searchType, showTargetId, targetId, targetType],
   );
 
-  const refresh = useCallback(async () => {
-    if (!mountedRef.current) {
-      return;
+  useEffect(() => {
+    if (!enabled || !loginUserId) {
+      setLoading(false);
+      setLoadingMore(false);
+      setData([]);
+      setHasMore(false);
+      setError(null);
+      return undefined;
     }
 
+    let cancelled = false;
+
+    async function init() {
+      setLoading(true);
+      setError(null);
+      setPage(0);
+      setHasMore(true);
+
+      try {
+        await fetchData(0);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err?.message || 'Failed to load feed');
+          setData([]);
+          setHasMore(false);
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    init();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled, fetchData, loginUserId]);
+
+  const loadMore = useCallback(async () => {
+    const newPage = page + 1;
+    setLoadingMore(true);
+    setPage(newPage);
+
+    try {
+      await fetchData(newPage);
+    } catch (err) {
+      setError(err?.message || 'Failed to load feed');
+      setHasMore(false);
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [fetchData, page]);
+
+  const refresh = useCallback(async () => {
     setLoading(true);
     setError(null);
     setPage(0);
@@ -194,10 +208,12 @@ const useSearchFeed = ({
 
     try {
       await fetchData(0);
+    } catch (err) {
+      setError(err?.message || 'Failed to load feed');
+      setData([]);
+      setHasMore(false);
     } finally {
-      if (mountedRef.current) {
-        setLoading(false);
-      }
+      setLoading(false);
     }
   }, [fetchData]);
 
@@ -213,77 +229,6 @@ const useSearchFeed = ({
     });
     setError(null);
   }, []);
-
-  useEffect(() => {
-    mountedRef.current = true;
-
-    return () => {
-      mountedRef.current = false;
-      abortInflightRequest();
-    };
-  }, [abortInflightRequest]);
-
-  useEffect(() => {
-    if (!enabled) {
-      abortInflightRequest();
-      setLoading(false);
-      setLoadingMore(false);
-      setError(null);
-      setData([]);
-      setHasMore(false);
-      return undefined;
-    }
-
-    if (!loginUserId) {
-      abortInflightRequest();
-      setLoading(false);
-      setData([]);
-      setHasMore(false);
-      return undefined;
-    }
-
-    let active = true;
-
-    async function init() {
-      setLoading(true);
-      setError(null);
-      setPage(0);
-      setHasMore(true);
-
-      try {
-        await fetchData(0);
-      } finally {
-        if (active && mountedRef.current) {
-          setLoading(false);
-        }
-      }
-    }
-
-    init();
-
-    return () => {
-      active = false;
-      abortInflightRequest();
-    };
-  }, [abortInflightRequest, enabled, fetchData, loginUserId]);
-
-  const loadMore = useCallback(async () => {
-    if (!mountedRef.current) {
-      return;
-    }
-
-    const newPage = page + 1;
-    setLoadingMore(true);
-
-    try {
-      setPage(newPage);
-      await fetchData(newPage);
-    } finally {
-      if (mountedRef.current) {
-        setLoadingMore(false);
-      }
-    }
-  }, [fetchData, page]);
 
   return {
     posts: data,


### PR DESCRIPTION
## Summary

This PR fixes the Unity/social feed path after PR #28 was merged and deployed. The deployed shell was able to mount the Amity UI kit, but the feed initially rendered only the post composer and did not render the searched feed items. This change makes the content-search feed render the creator, loading/error states, posts, and empty state together, and makes the content-search hook less fragile around SDK/user readiness.

## What Changed

- Wrapped the `ConditionalRender` true branch in `src/social/components/Feed/index.js` in a React fragment so all intended children render together.
  - Before this, only the first child in that branch could effectively survive the `ConditionalRender` path, so the post creator showed but the rest of the feed content was missing.
  - After this, the post creator, loading skeleton, error/retry UI, load-more list, empty state, and private-feed fallback all sit under one branch.

- Allowed posts to render whenever `posts.length > 0` instead of also requiring `!loading`.
  - In the Unity/content-search path we observed cases where data was present but the loading state could still suppress the list.
  - Rendering based on the actual post list prevents the blank-white-body symptom after content-search results arrive.

- Added a safer `loginUserId` fallback in `ContentSearchFeed`.
  - Primary source remains `currentUserId` from `useSDK()`.
  - Fallbacks are `client?.currentUserId`, then the Unity shell query-string `userId`.
  - This matters because the Unity embed passes `userId` in the URL and the SDK/user state can lag page render during initial connection.

- Simplified `useSearchFeed` request lifecycle.
  - The earlier abort-controller path was making the content-search path brittle while the surrounding SDK/provider state was still settling.
  - The hook now uses a local cancellation flag for the initial effect, keeps the latest data in a ref for pagination appends, and centralizes error handling for refresh/load-more.

- Added `window.__BBVR_FEED_DEBUG__` in browser environments.
  - This records the resolved `loginUserId`, result count, first few post IDs, and page index for the most recent content-search response.
  - It is intentionally tiny and was added because this bug was difficult to diagnose from the embedded Unity shell where the visible symptom was just a blank feed area.

## Why This Was Needed

After PR #28 was merged, the deployed Unity social page at `https://social.vrfr.io/?type=feed&userId=...` mounted the composer but did not show feed posts. The source problem was not one single issue:

1. The feed branch did not group multiple children for `ConditionalRender`, so the visible branch stopped after the creator instead of rendering the complete feed body.
2. The content-search path depended on SDK/user readiness at exactly the wrong time for the Unity shell embed.
3. The list rendering was too tightly coupled to `loading`, even when `posts` were already available.

## Validation

- Ran `npm run build` in this repo.
- Build passed.
- Existing warnings only:
  - Webpack asset size limit for `index.js`.
  - Entrypoint size limit.
  - Webpack performance/code-splitting recommendation.

## Deployment / Shell Relationship

This source PR is paired with a shell repo PR in `BlackBox-VR/bbvr-social`.

Important future-agent note: the production shell currently consumes this UI kit as a vendored `package.tgz`, not as a freshly published npm package. The matching shell PR includes a regenerated `package.tgz` whose SHA-256 matches the tarball generated from this checkout:

`355c328d251d82062f7d94b2c26d3549c1b292a383b705912cc4f6a1a33e4c01`

If this UI kit PR changes before merge, regenerate the shell `package.tgz`, rebuild the shell, and redeploy/revalidate.

## Future AI Agent Notes

- Do not assume the Unity social embed behaves like a normal standalone Amity page. The shell passes identity and route mode through query params such as `type=feed`, `userId`, `username`, and `auth`.
- The content-search feed is sensitive to SDK connection timing. If a future regression shows a blank body, first check the resolved `loginUserId` and `window.__BBVR_FEED_DEBUG__` in the browser.
- If posts are returned by the content-search API but not visible, inspect `FeedBody` before chasing CSS. We already hit a render-branch issue here.
- If posts are visible locally but not in production shell, inspect the shell repo's vendored `package.tgz` and dependency resolution. The shell can be out of sync with this source repo.
- The deployed shell has also needed runtime/style fixes outside this repo, including a `react-loading-skeleton` pin and CSS overrides for BBVR's desired white post/composer surfaces.
